### PR TITLE
Reenable fix for issue #49 and solve issue #66

### DIFF
--- a/src/main/java/org/writingtool/WtDocumentsHandler.java
+++ b/src/main/java/org/writingtool/WtDocumentsHandler.java
@@ -1935,11 +1935,15 @@ public class WtDocumentsHandler {
           return;
         }
 
-/*        boolean saveNoBackgroundCheck = noBackgroundCheck;
-        if (noBackgroundCheck && toggleNoBackgroundCheck()) {
-          resetCheck();
+        boolean saveNoBackgroundCheck = isBackgroundCheckOff();
+        if (isBackgroundCheckOff()) {
+          if (toggleNoBackgroundCheck()) {
+            resetCheck();
+          } else {
+            saveNoBackgroundCheck = false;
+          }
         }
-*/
+
         setLtDialogIsRunning(true);
         WtCheckDialog checkDialog = new WtCheckDialog(xContext, this, docLanguage, waitDialog);
         if ("checkAgainDialog".equals(sEvent)) {
@@ -1958,15 +1962,14 @@ public class WtDocumentsHandler {
             }
           }
           resetIgnoredMatches();
-/*
-          if (saveNoBackgroundCheck) {
-             toggleNoBackgroundCheck();
-          }
-*/
+
 //          resetCheck();
         }
-        if (debugMode) {
-          
+
+        if (saveNoBackgroundCheck) {
+           toggleNoBackgroundCheck();
+        }
+        if (debugMode) {        
           WtMessageHandler.printToLogFile("MultiDocumentsHandler: trigger: Start Spell And Grammar Check Dialog");
         }
         checkDialog.start();


### PR DESCRIPTION
This fixes both issues #49 and #66, mostly by uncommenting your own code.
I used the method `isBackgroundCheckOff` as the rest of your code.
I also took into account the possibility that the method "toggleNoBackgroundCheck"
might fail and return false, in which case the setting should not be toggled again to restore it,
to be consistent with the fact that you are checking for its return value.

I didn't test to see if it actually works, I just guessed how to fix it.
Feel free to change anything as you would like.
Thanks for all.