### PR TITLE
Fix ErrorSortTest expectations to match current sorting logic

### DIFF
--- a/src/test/java/org/writingtool/ErrorSortTest.java
+++ b/src/test/java/org/writingtool/ErrorSortTest.java
@@ -48,9 +48,9 @@ public class ErrorSortTest {
     assertEquals("C2", aError[3].aRuleIdentifier);
     assertEquals("D1", aError[4].aRuleIdentifier);
     assertEquals("E1", aError[5].aRuleIdentifier);
-    assertEquals("F1", aError[6].aRuleIdentifier);
-    assertEquals("F2", aError[7].aRuleIdentifier);
-    assertEquals("F3", aError[8].aRuleIdentifier);
+    assertEquals("F3", aError[6].aRuleIdentifier);
+    assertEquals("F1", aError[7].aRuleIdentifier);
+    assertEquals("F2", aError[8].aRuleIdentifier);
     assertEquals("F4", aError[9].aRuleIdentifier);
     assertEquals("F5", aError[10].aRuleIdentifier);
     


### PR DESCRIPTION
    Update testIsCorrectSortTest() to align with sorting behavior from commit 8b766d9.
    The comparator now prioritizes errors with exactly 1 suggestion over those with
    different suggestion counts when position and length are equal.

    - F3 (1 suggestion) now correctly expected at position 6
    - F1, F2 (2 suggestions) follow at positions 7-8
    - Test expectations updated from outdated January logic to current June behavior